### PR TITLE
Change `Rect.rect` to `Door.rect`

### DIFF
--- a/Tutorial/Part15.md
+++ b/Tutorial/Part15.md
@@ -157,7 +157,7 @@ if world.player.intersection(with: self) != nil ||
     }) {
 ```
 
-The doors will now open if a (living) monster touches them. We'll also make it a little easier for our zombie friends by increasing the thickness of the door collision rectangle. In the computed `Rect.rect` property, replace the line:
+The doors will now open if a (living) monster touches them. We'll also make it a little easier for our zombie friends by increasing the thickness of the door collision rectangle. In the computed `Door.rect` property, replace the line:
 
 ```swift
 return Rect(min: position, max: position + direction)


### PR DESCRIPTION
Correct the computed property signature name in the **Out of Sight, Out of Mind** section. `Rect.rect` isn't really correct there.